### PR TITLE
Add polling interval and fix missing 404 response handler

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import time
 from http.server import SimpleHTTPRequestHandler, HTTPServer
 from PIL import Image
 from pyzbar.pyzbar import decode
@@ -107,6 +108,8 @@ def decode_chunked_results():
                 print(f"[+] Complete result from {result_id}:\n{complete_output}")
                 del assembled_results[result_id]
 
+        time.sleep(POLL_INTERVAL)
+
 
 class C2ServerHandler(SimpleHTTPRequestHandler):
     def log_message(self, format, *args):
@@ -124,6 +127,9 @@ class C2ServerHandler(SimpleHTTPRequestHandler):
             else:
                 self.send_response(404)
                 self.end_headers()
+        else:
+            self.send_response(404)
+            self.end_headers()
 
     def do_POST(self):
         if self.path.startswith('/result'):


### PR DESCRIPTION
## Summary
This PR improves the C2 server's request handling and polling behavior by adding a configurable polling interval to the result decoding loop and fixing a missing 404 response for unhandled GET requests.

## Key Changes
- **Added polling interval**: Introduced `time.sleep(POLL_INTERVAL)` in the `decode_chunked_results()` function to prevent busy-waiting and reduce CPU usage during result polling
- **Fixed incomplete GET handler**: Added missing `else` clause in `C2ServerHandler.do_GET()` to properly respond with 404 status for requests that don't match any defined paths
- **Added time import**: Imported the `time` module to support the polling interval functionality

## Implementation Details
- The polling interval sleep is placed at the end of the `decode_chunked_results()` loop, ensuring the server doesn't continuously poll for results without delay
- The 404 response handler now properly closes the connection with `end_headers()` for unmatched GET requests, preventing potential connection issues
- These changes improve both performance (reduced CPU usage) and protocol compliance (proper HTTP responses)

https://claude.ai/code/session_01HcoQ1VfxXWYW1Ba75AkdMT